### PR TITLE
Add failing test fixture for EncapsedStringsToSprintfRector

### DIFF
--- a/rules/coding-style/tests/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/prefixed_eol.php.inc
+++ b/rules/coding-style/tests/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/prefixed_eol.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\EncapsedStringsToSprintfRector\Fixture;
+
+final class PrefixedEol
+{
+    public function run(string $format)
+    {
+        return "prefix $format\n";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\EncapsedStringsToSprintfRector\Fixture;
+
+final class PrefixedEol
+{
+    public function run(string $format)
+    {
+        return sprintf('prefix %s%s', $format, PHP_EOL);
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for EncapsedStringsToSprintfRector

Based on https://getrector.org/demo/1b647b4f-dde9-4f90-b05e-74744045a3d1